### PR TITLE
truncate logs to 1000

### DIFF
--- a/redzone/utils/logger.py
+++ b/redzone/utils/logger.py
@@ -1,10 +1,20 @@
+import logging
+
 from microgue.loggers.logger import Logger as _Logger
 
 from ..settings import PROJECT_NAME
 
+MAX_LOG_LENGTH = 1000
+
 
 class Logger(_Logger):
-    pass
+    __instance = None
+
+    def log(self, message, priority=None, level=logging.DEBUG):
+        message = str(message)
+        if len(message) > MAX_LOG_LENGTH:
+            message = message[:MAX_LOG_LENGTH] + "... (truncated)"
+        super().log(message, priority, level)
 
 
 logger = Logger(PROJECT_NAME)

--- a/redzone/utils/logger.py
+++ b/redzone/utils/logger.py
@@ -4,8 +4,6 @@ from microgue.loggers.logger import Logger as _Logger
 
 from ..settings import PROJECT_NAME
 
-MAX_LOG_LENGTH = 1000
-
 
 class Logger(_Logger):
     __instance = None
@@ -13,8 +11,8 @@ class Logger(_Logger):
 
     def log(self, message, priority=None, level=logging.DEBUG):
         message = str(message)
-        if len(message) > MAX_LOG_LENGTH:
-            message = message[:MAX_LOG_LENGTH] + "... (truncated)"
+        if len(message) > self.max_log_length:
+            message = message[:self.max_log_length] + "... (truncated)"  # fmt: skip
         super().log(message, priority, level)
 
 

--- a/redzone/utils/logger.py
+++ b/redzone/utils/logger.py
@@ -9,6 +9,7 @@ MAX_LOG_LENGTH = 1000
 
 class Logger(_Logger):
     __instance = None
+    max_log_length = 1000
 
     def log(self, message, priority=None, level=logging.DEBUG):
         message = str(message)


### PR DESCRIPTION
Ran into some tricky behavior not being able override the log method without doing `__instance = None`.  It seems like since the parent class is a singleton, it uses the parent class methods instead of the subclass without resetting __instance.

Here is an example of what a log would look like truncated to 1000 chars:


core                  | 020d3b:DEBUG:core:body: {"fire":{"id":"73413116-a456-401d-bc86-89d8ba6e65dc","name":"Test Fire","type":"wildfire","acreage":12165378.663316999,"containment":50.0,"severity":23.03964434677054,"locked":false,"discovered_at":null,"estimated_contained_at":null,"city":null,"county":null,"state":null,"country":null,"latitude":0.0,"longitude":0.0,"behavior":null,"projected_activity_12_hour":null,"significant_events":null,"rate_of_spread":null,"management_complexity":null,"planned_actions":null,"residences_destroyed":null,"residences_threatened":null,"other_structures_destroyed":null,"other_structures_threatened":null,"total_incident_personnel":null,"weather_concerns":null,"links":{},"created_at":"2025-10-29T23:00:37.681940Z","modified_at":"2025-10-29T23:00:37.681940Z","origin":{"type":"Point","coordinates":[0.0,0.0]},"perimeter":{"type":"MultiPolygon","coordinates":[[[[0.0,0.0],[2.0,0.0],[2.0,2.0],[0.0,2.0],[0.0,0.0]]]]},"buffer":{"type":"MultiPolygon","coordinates":[[[[-0.1444179610808087,0.000132967726560779... (truncated)
