### PR TITLE
Enable Library Logs

### DIFF
--- a/redzone/bootstrap.py
+++ b/redzone/bootstrap.py
@@ -22,7 +22,6 @@ if ENVIRONMENT in ["staging", "sandbox", "production"]:
     )
 
 # disable 3rd party logging
-logging.getLogger().setLevel(logging.CRITICAL)
 logging.getLogger("aiobotocore").setLevel(logging.CRITICAL)
 logging.getLogger("asyncio").setLevel(logging.CRITICAL)
 logging.getLogger("boto3").setLevel(logging.CRITICAL)


### PR DESCRIPTION
This pull request makes a small change to the logging configuration in `redzone/bootstrap.py`. The root logger is no longer being set to `CRITICAL` level, which means only the log levels for specific third-party libraries are being adjusted.

This should fix the suppression of microgue logs.